### PR TITLE
Implemented tab history, keep track of tab switch order

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Download: https://chrome.google.com/webstore/detail/toggle-switch-recent-last/od
 Changelog
 =========
 
+**1.5**
+
+ - Implemented tab history, keep track of tab switch order
+ - When closing tabs, switch to last focused existing tab.
+
 **1.4.2**
 
  - Reverted back to toggle command instead of browser action
@@ -31,7 +36,7 @@ Changelog
 - Switched from onSelectionChanged to onActivated: When opening a new tab, switch to last focused tab is now possible.
 - Use local storage and persistent: true: Fixes issue with Chrome not saving the tab variables persistently
 
-**1.1** 
+**1.1**
 
 - Now uses native Chrome keyboard command instead of JS
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 	},
 	"name": "Toggle Switch Recent Last Tabs",
 	"short_name": "TSRLT",
-	"version": "1.4.2",
+	"version": "1.5",
 	"manifest_version": 2,
 	"description": "Toggle between your current and last used (focused) tab with a keyboard shortcut (ALT+Q by default) or mouse click on the icon.",
 	"browser_action": {


### PR DESCRIPTION
Using an array of tab ids to keep track of tabs, it can just iterate through it, and always find the last **valid** focused tab.
So no matter how much opening/closing you do, it will still work.

I updated the version and readme file according to your commit history,
so if you want you can merge this one, but if you really don't want to keep track of more than 3 tabs, i'll understand.